### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/MuEvent.pm
+++ b/lib/MuEvent.pm
@@ -1,5 +1,5 @@
 #= Event-driven programming in Perl 6
-module MuEvent;
+unit module MuEvent;
 
 my @timers;
 my @sockets;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.